### PR TITLE
group source error bug fixed

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,14 +7,14 @@ groups = {}
 
 @itchat.msg_register(TEXT, isGroupChat=True)
 def group_reply_text(msg):
-    fromUserName = msg['FromUserName']
-    source = msg['ToUserName']
+    source = msg['FromUserName']
     if msg['Content'] == 'Hi':
-        groups[source] = source 
-    if groups.has_key(fromUserName):
-        for item in groups.keys():
-            if not item == fromUserName:
-                itchat.send(' %s say:\n%s' % (msg['ActualNickName'], msg['Content']), item)
+        groups[source] = source
+    else:
+        if groups.has_key(source):
+            for item in groups.keys():
+                if not item == source:
+                    itchat.send(' %s say:\n%s' % (msg['ActualNickName'], msg['Content']), item)
 
 @itchat.msg_register(PICTURE, isGroupChat=True)
 def group_reply_media(msg):


### PR DESCRIPTION
Group source in the server is not ToUserName, it’s FromUserName. 
Error occurred when I tested it to send messages to another group. Don't know whether there is environment problem or not. Python 2.7.10
在机器人端，群消息来源的名称是FromUserName.
我自己测试发消息到别的群有问题，不知道是不是环境问题。Python 2.7.10